### PR TITLE
chore: changes the CLA action trigger to pull_request_target

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,7 +9,7 @@ permissions:
 
 on:
   merge_group:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
     branches:
       - main


### PR DESCRIPTION
This PR updates the CLA Actions workflow trigger from `pull_request` to `pull_request_target`.

